### PR TITLE
Replaced OPTIONAL with UNION in PropertiesToPatternHandler

### DIFF
--- a/src/main/java/org/springframework/data/semantic/support/convert/EntityToQueryConverter.java
+++ b/src/main/java/org/springframework/data/semantic/support/convert/EntityToQueryConverter.java
@@ -104,9 +104,8 @@ public class EntityToQueryConverter {
 		sb.append(getPropertyBindings(uri, entity, propertyToValue, globalMappingPolicy, originalPredicates));
 		sb.append(" }\n");
 		sb.append("WHERE { ");
-		sb.append(getPropertyPatterns(uri, entity, propertyToValue, false, globalMappingPolicy));
+		sb.append(getPropertyPatterns(uri, entity, propertyToValue, false, globalMappingPolicy, true));
 		sb.append(" }");
-		
 		return sb.toString();
 	}
 	
@@ -119,10 +118,9 @@ public class EntityToQueryConverter {
 		StringBuilder sb = new StringBuilder();
 		String subjectBinding  = getSubjectBinding(null, entity);
 		sb.append("SELECT (COUNT (DISTINCT "+subjectBinding+") as ?count) WHERE { "+subjectBinding+" a <"+entity.getRDFType()+"> . ");
-		sb.append(getPropertyPatterns(null, entity, propertyToValue, true, MappingPolicyImpl.ALL_POLICY));
+		sb.append(getPropertyPatterns(null, entity, propertyToValue, true, MappingPolicyImpl.ALL_POLICY, false));
 		sb.append("}");
 		return sb.toString();
-		
 	}
 	
 	/**
@@ -157,7 +155,7 @@ public class EntityToQueryConverter {
 		sb.append(getPropertyBindings(null, entity, propertyToValue, MappingPolicyImpl.ALL_POLICY, false));
 		sb.append(" }\n");
 		sb.append("WHERE { ");
-		sb.append(getPropertyPatterns(null, entity, propertyToValue, false, MappingPolicyImpl.ALL_POLICY));
+		sb.append(getPropertyPatterns(null, entity, propertyToValue, false, MappingPolicyImpl.ALL_POLICY, false));
 		sb.append(" }");
 		
 		return sb.toString();
@@ -208,7 +206,7 @@ public class EntityToQueryConverter {
 		return sb.toString();
 	}
 	
-	protected String getPropertyPatterns(URI uri, SemanticPersistentEntity<?> entity, Map<String, Object> propertyToValue, boolean isCount, MappingPolicy globalMappingPolicy){
+	protected String getPropertyPatterns(URI uri, SemanticPersistentEntity<?> entity, Map<String, Object> propertyToValue, boolean isCount, MappingPolicy globalMappingPolicy, boolean useUnions){
 		StringBuilder sb = new StringBuilder();
 		/*SemanticPersistentProperty contextP = entity.getContextProperty();
 		if(contextP != null){
@@ -224,7 +222,7 @@ public class EntityToQueryConverter {
 			binding = "?"+entity.getRDFType().getLocalName();
 		}
 		AbstractPropertiesToQueryHandler.appendPattern(sb, binding, "<"+ValueUtils.RDF_TYPE_PREDICATE+">", "<"+entity.getRDFType()+">");
-		PropertiesToPatternsHandler handler = new PropertiesToPatternsHandler(sb, binding, propertyToValue, this.mappingContext, isCount, false, globalMappingPolicy);
+		PropertiesToPatternsHandler handler = new PropertiesToPatternsHandler(sb, binding, propertyToValue, this.mappingContext, isCount, false, globalMappingPolicy, useUnions);
 		entity.doWithProperties(handler);
 		entity.doWithAssociations(handler);
 		return sb.toString();

--- a/src/test/java/org/springframework/data/semantic/support/convert/TestEntityToQueryConverter.java
+++ b/src/test/java/org/springframework/data/semantic/support/convert/TestEntityToQueryConverter.java
@@ -44,9 +44,13 @@ public class TestEntityToQueryConverter {
 	private String expectedBindingsEager = "<http://ontotext.com/resource/test-collection> a <urn:spring-data-semantic:ModelEntityCollector> . <http://ontotext.com/resource/test-collection> <urn:modelentitycollector:field:entities> ?modelentitycollector_entities . ?modelentitycollector_entities a <urn:spring-data-semantic:ModelEntity> . ?modelentitycollector_entities <urn:modelentity:field:name> ?modelentitycollector_entities_modelentity_name . ?modelentitycollector_entities <urn:modelentity:field:synonyms> ?modelentitycollector_entities_modelentity_synonyms . ?modelentitycollector_entities <urn:modelentity:field:related> ?modelentitycollector_entities_modelentity_related . ";
 	private String expectedPatternEager = "<http://ontotext.com/resource/test-collection> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <urn:spring-data-semantic:ModelEntityCollector> . <http://ontotext.com/resource/test-collection> <urn:spring-data-semantic:entities> ?modelentitycollector_entities . ?modelentitycollector_entities <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <urn:spring-data-semantic:ModelEntity> . OPTIONAL { ?modelentitycollector_entities <http://www.w3.org/2004/02/skos/core#prefLabel> ?modelentitycollector_entities_modelentity_name . } OPTIONAL { ?modelentitycollector_entities <http://www.w3.org/2004/02/skos/core#altLabel> ?modelentitycollector_entities_modelentity_synonyms . } OPTIONAL { ?modelentitycollector_entities <urn:spring-data-semantic:related> ?modelentitycollector_entities_modelentity_related . } ";
 	private String expectedQueryEager = "CONSTRUCT { "+expectedBindingsEager+" } WHERE { "+expectedPatternEager+"}";
-	
-	
-	private URI resource = new URIImpl("http://ontotext.com/resource/test");
+
+    private String expectedBindingsUnion = "<http://ontotext.com/resource/test> a <urn:spring-data-semantic:ModelEntity> . <http://ontotext.com/resource/test> <urn:modelentity:field:name> ?modelentity_name . <http://ontotext.com/resource/test> <urn:modelentity:field:synonyms> ?modelentity_synonyms . <http://ontotext.com/resource/test> <urn:modelentity:field:related> ?modelentity_related . ";
+    private String expectedPatternUnion = "<http://ontotext.com/resource/test> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <urn:spring-data-semantic:ModelEntity> . {} UNION { <http://ontotext.com/resource/test> <http://www.w3.org/2004/02/skos/core#prefLabel> ?modelentity_name . } UNION { <http://ontotext.com/resource/test> <http://www.w3.org/2004/02/skos/core#altLabel> ?modelentity_synonyms . } {} UNION { { <http://ontotext.com/resource/test> <urn:spring-data-semantic:related> ?modelentity_related . } } ";
+    private String expectedQueryUnion = "CONSTRUCT { "+expectedBindingsUnion+" } WHERE { "+expectedPatternUnion+"}";
+
+
+    private URI resource = new URIImpl("http://ontotext.com/resource/test");
 	
 	private URI collectionResource = new URIImpl("http://ontotext.com/resource/test-collection");
 	
@@ -84,7 +88,7 @@ public class TestEntityToQueryConverter {
 
 	@Test
 	public void TestPatternCreation(){
-		String queryPattern = entityToQueryConverter.getPropertyPatterns(resource, testEntityType, new HashMap<String, Object>(), false, MappingPolicyImpl.ALL_POLICY);
+		String queryPattern = entityToQueryConverter.getPropertyPatterns(resource, testEntityType, new HashMap<String, Object>(), false, MappingPolicyImpl.ALL_POLICY, false);
 		String[] expected = expectedPattern.replaceAll("\\{|\\}", " ").replaceAll("\\s+", " ").split(" \\. ");
 		String[] resultPattern = queryPattern.replaceAll("\\{|\\}", " ").replaceAll("\\s+", " ").split(" \\. ");
 		Arrays.sort(expected, comparator);
@@ -97,7 +101,7 @@ public class TestEntityToQueryConverter {
 	@Test
 	public void TestGraphQueryCreation(){
 		String query = entityToQueryConverter.getGraphQueryForResource(resource, testEntityType, MappingPolicyImpl.ALL_POLICY);
-		String[] expected = expectedQuery.replaceAll("\\{|\\}", " ").replaceAll("\\s+", " ").split(" \\. ");
+		String[] expected = expectedQueryUnion.replaceAll("\\{|\\}", " ").replaceAll("\\s+", " ").split(" \\. ");
 		String[] resultBindings = query.replaceAll("\\{|\\}", " ").replaceAll("\\s+", " ").split(" \\. ");
 		Arrays.sort(expected, comparator);
 		Arrays.sort(resultBindings, comparator);
@@ -116,7 +120,7 @@ public class TestEntityToQueryConverter {
 	
 	@Test
 	public void TestPatternCreationEagerLoad(){
-		String queryPattern = entityToQueryConverter.getPropertyPatterns(collectionResource, testCollectionType, new HashMap<String, Object>(), false, MappingPolicyImpl.ALL_POLICY);
+		String queryPattern = entityToQueryConverter.getPropertyPatterns(collectionResource, testCollectionType, new HashMap<String, Object>(), false, MappingPolicyImpl.ALL_POLICY, false);
 		String[] expected = expectedPatternEager.replaceAll("\\{|\\}", " ").replaceAll("\\s+", " ").split(" \\. ");
 		String[] resultPattern = queryPattern.replaceAll("\\{|\\}", " ").replaceAll("\\s+", " ").split(" \\. ");
 		Arrays.sort(expected, comparator);


### PR DESCRIPTION
This is done only for `getGraphQueryForResource` function in `EntityToQueryConverter`, which  works fine for us. 
Also touched the corresponding test.